### PR TITLE
初期ユニットを建築者1体のみに変更する

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -201,17 +201,7 @@ export class GameScene extends Phaser.Scene {
 
   private spawnInitialUnits(): void {
     const midRow = Math.floor(MAP_ROWS / 2);
-    // Spawn veggies near the river
     this.addUnit(new Potato(this, 5, midRow - 4));
-    this.addUnit(new Potato(this, 7, midRow - 4));
-    this.addUnit(new Daikon(this, 6, midRow - 5));
-    this.addUnit(new Daikon(this, 8, midRow - 5));
-    this.addUnit(new Chili(this, 4, midRow - 3));
-    this.addUnit(new Chili(this, 9, midRow - 3));
-
-    // Spawn initial enemies at map edges
-    this.addUnit(new Aphid(this, 0, 2));
-    this.addUnit(new Aphid(this, MAP_COLS - 1, MAP_ROWS - 3));
   }
 
   private spawnEnemy(): void {


### PR DESCRIPTION
## Summary
- ゲーム開始時の初期ユニットを Potato（Builder）1体のみに変更
- Daikon×2, Chili×2, Aphid×2 の初期配置を削除

## Changes
- `src/scenes/GameScene.ts`: `spawnInitialUnits()` メソッドを Potato 1体のみ配置するように変更

Ref #18

## Test plan
- [x] `npm run build` (tsc + vite build) 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)