### PR TITLE
ユニットの種類が色で判別できない：凡例・ラベルの追加

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -179,6 +179,25 @@ export class GameScene extends Phaser.Scene {
     this.highlightGraphics.lineStyle(2, 0xffffff, 0.5);
     this.highlightGraphics.strokeRect(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE - 1, TILE_SIZE - 1);
 
+    // Check for unit under cursor
+    const hoveredUnit = this.units.find(u => {
+      if (!u.alive) return false;
+      const dx = worldX - u.x;
+      const dy = worldY - u.y;
+      return dx * dx + dy * dy <= (TILE_SIZE * 0.35) * (TILE_SIZE * 0.35);
+    });
+
+    if (hoveredUnit) {
+      this.hud.showUnitInfo(
+        hoveredUnit.getLabel(),
+        hoveredUnit.team,
+        hoveredUnit.hp,
+        hoveredUnit.stats.maxHp,
+      );
+    } else {
+      this.hud.clearUnitInfo();
+    }
+
     // Show info
     const terrain = this.grid.getTerrain(col, row);
     let extra = "";

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -3,12 +3,27 @@ import { TILE_SIZE } from "../terrain/TerrainGrid";
 
 export type PlacementMode = "build" | "seed" | null;
 
+interface LegendEntry {
+  color: number;
+  label: string;
+  team: string;
+}
+
+const UNIT_LEGEND: LegendEntry[] = [
+  { color: 0xddb860, label: "Potato", team: "Veggie" },
+  { color: 0xeeeedd, label: "Daikon", team: "Veggie" },
+  { color: 0xcc3333, label: "Chili", team: "Veggie" },
+  { color: 0x44aa44, label: "Aphid", team: "Pest" },
+];
+
 export class HUD {
   private scene: Phaser.Scene;
   private modeText: Phaser.GameObjects.Text;
   private infoText: Phaser.GameObjects.Text;
+  private unitInfoText: Phaser.GameObjects.Text;
   private buildBtn: Phaser.GameObjects.Text;
   private seedBtn: Phaser.GameObjects.Text;
+  private legendGraphics: Phaser.GameObjects.Graphics;
   placementMode: PlacementMode = null;
 
   constructor(scene: Phaser.Scene) {
@@ -46,6 +61,69 @@ export class HUD {
     })
       .setScrollFactor(0)
       .setDepth(100);
+
+    this.unitInfoText = scene.add.text(10, 70, "", {
+      fontSize: "12px",
+      color: "#ffffff",
+      backgroundColor: "#333355",
+      padding: { x: 6, y: 3 },
+    })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    // Legend panel
+    this.legendGraphics = scene.add.graphics();
+    this.legendGraphics.setScrollFactor(0);
+    this.legendGraphics.setDepth(100);
+    this.drawLegend();
+  }
+
+  private drawLegend(): void {
+    const cam = this.scene.cameras.main;
+    const panelX = cam.width - 120;
+    const panelY = 10;
+    const rowHeight = 20;
+    const panelHeight = UNIT_LEGEND.length * rowHeight + 30;
+
+    // Background
+    this.legendGraphics.fillStyle(0x222244, 0.85);
+    this.legendGraphics.fillRoundedRect(panelX - 10, panelY, 120, panelHeight, 6);
+
+    // Title
+    const title = this.scene.add.text(panelX, panelY + 6, "Units", {
+      fontSize: "12px",
+      fontStyle: "bold",
+      color: "#ffcc44",
+    })
+      .setScrollFactor(0)
+      .setDepth(101);
+
+    // Entries
+    UNIT_LEGEND.forEach((entry, i) => {
+      const y = panelY + 26 + i * rowHeight;
+      // Color dot
+      this.legendGraphics.fillStyle(entry.color, 1);
+      this.legendGraphics.fillCircle(panelX + 6, y + 6, 5);
+      // Initial letter
+      this.scene.add.text(panelX + 2, y, entry.label[0], {
+        fontSize: "8px",
+        fontStyle: "bold",
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 1,
+      })
+        .setOrigin(0.5, 0)
+        .setPosition(panelX + 6, y + 1)
+        .setScrollFactor(0)
+        .setDepth(102);
+      // Label
+      this.scene.add.text(panelX + 18, y, entry.label, {
+        fontSize: "11px",
+        color: entry.team === "Pest" ? "#ff8888" : "#aaddaa",
+      })
+        .setScrollFactor(0)
+        .setDepth(101);
+    });
   }
 
   toggleMode(mode: PlacementMode): void {
@@ -75,6 +153,14 @@ export class HUD {
 
   showTileInfo(col: number, row: number, terrain: string, extra: string): void {
     this.infoText.setText(`Tile (${col}, ${row}) — ${terrain}${extra ? "\n" + extra : ""}`);
+  }
+
+  showUnitInfo(name: string, team: string, hp: number, maxHp: number): void {
+    this.unitInfoText.setText(`${name} (${team}) — HP: ${Math.floor(hp)}/${maxHp}`);
+  }
+
+  clearUnitInfo(): void {
+    this.unitInfoText.setText("");
   }
 
   worldToTile(worldX: number, worldY: number): { col: number; row: number } {

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -20,6 +20,7 @@ export abstract class Unit {
   targetCol: number;
   targetRow: number;
   graphics: Phaser.GameObjects.Graphics;
+  labelText: Phaser.GameObjects.Text;
   alive: boolean = true;
   lastAttackTime: number = 0;
 
@@ -45,6 +46,15 @@ export abstract class Unit {
     this.prevRow = row;
     this.graphics = scene.add.graphics();
     this.graphics.setDepth(10);
+    this.labelText = scene.add.text(0, 0, this.getLabel()[0], {
+      fontSize: "11px",
+      fontStyle: "bold",
+      color: "#ffffff",
+      stroke: "#000000",
+      strokeThickness: 2,
+    });
+    this.labelText.setOrigin(0.5, 0.5);
+    this.labelText.setDepth(11);
   }
 
   get x(): number {
@@ -106,7 +116,10 @@ export abstract class Unit {
 
   draw(): void {
     this.graphics.clear();
-    if (!this.alive) return;
+    if (!this.alive) {
+      this.labelText.setVisible(false);
+      return;
+    }
 
     const cx = this.x;
     const cy = this.y;
@@ -115,6 +128,10 @@ export abstract class Unit {
     // Body
     this.graphics.fillStyle(this.getColor(), 1);
     this.graphics.fillCircle(cx, cy, radius);
+
+    // Label
+    this.labelText.setPosition(cx, cy);
+    this.labelText.setVisible(true);
 
     // HP bar
     const barWidth = TILE_SIZE * 0.8;
@@ -131,6 +148,7 @@ export abstract class Unit {
 
   destroy(): void {
     this.graphics.destroy();
+    this.labelText.destroy();
   }
 
   distanceTo(col: number, row: number): number {


### PR DESCRIPTION
## Summary
- ユニット上に頭文字ラベル（P/D/C/A）を直接表示し、色だけでなく文字でも種類を判別可能に
- 画面右上に凡例（レジェンド）パネルを追加し、全ユニット種の色・名前・所属チームを一覧表示
- ユニットにマウスホバーすると名前・HP・チーム情報をHUDに表示

## Changes
- `src/units/Unit.ts`: ユニット円の中央に頭文字ラベルを描画する Text オブジェクトを追加
- `src/ui/HUD.ts`: 凡例パネルとユニット情報表示機能を追加
- `src/scenes/GameScene.ts`: ユニットへのホバー検出ロジックを追加

Ref #20

## Test plan
- [x] `npm run build` — TypeScript 型チェック + Vite ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)