### PR TITLE
アブラムシが川の向こう側にスポーンし戦闘が発生しない

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -209,22 +209,30 @@ export class GameScene extends Phaser.Scene {
     this.addUnit(new Chili(this, 4, midRow - 3));
     this.addUnit(new Chili(this, 9, midRow - 3));
 
-    // Spawn initial enemies at map edges
+    // Spawn initial enemies on the same side as veggies (north of river)
     this.addUnit(new Aphid(this, 0, 2));
-    this.addUnit(new Aphid(this, MAP_COLS - 1, MAP_ROWS - 3));
+    this.addUnit(new Aphid(this, MAP_COLS - 1, 2));
   }
 
   private spawnEnemy(): void {
-    const edge = Math.floor(Math.random() * 4);
-    let col: number, row: number;
-    switch (edge) {
-      case 0: col = 0; row = Math.floor(Math.random() * MAP_ROWS); break;
-      case 1: col = MAP_COLS - 1; row = Math.floor(Math.random() * MAP_ROWS); break;
-      case 2: col = Math.floor(Math.random() * MAP_COLS); row = 0; break;
-      default: col = Math.floor(Math.random() * MAP_COLS); row = MAP_ROWS - 1; break;
-    }
-    if (this.grid.isPassable(col, row)) {
+    // Find a reference veggie position for reachability check
+    const veggie = this.units.find(u => u.alive && u.team === "veggie");
+    const maxAttempts = 10;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const edge = Math.floor(Math.random() * 4);
+      let col: number, row: number;
+      switch (edge) {
+        case 0: col = 0; row = Math.floor(Math.random() * MAP_ROWS); break;
+        case 1: col = MAP_COLS - 1; row = Math.floor(Math.random() * MAP_ROWS); break;
+        case 2: col = Math.floor(Math.random() * MAP_COLS); row = 0; break;
+        default: col = Math.floor(Math.random() * MAP_COLS); row = MAP_ROWS - 1; break;
+      }
+      if (!this.grid.isPassable(col, row)) continue;
+      // Ensure the spawn position can reach a veggie unit
+      if (veggie && !this.grid.isReachable(col, row, veggie.col, veggie.row)) continue;
       this.addUnit(new Aphid(this, col, row));
+      return;
     }
   }
 

--- a/src/systems/AISystem.ts
+++ b/src/systems/AISystem.ts
@@ -142,44 +142,25 @@ export class AISystem {
   }
 
   private moveToward(unit: Unit, targetCol: number, targetRow: number, grid: TerrainGrid): void {
+    // Use BFS pathfinding to navigate around obstacles (rivers, limestone)
+    const path = grid.findPath(unit.col, unit.row, targetCol, targetRow);
+    if (path && path.length > 0) {
+      unit.moveTo(path[0].col, path[0].row);
+      return;
+    }
+    // Fallback: greedy movement if BFS fails (e.g., unreachable target)
     const dx = Math.sign(targetCol - unit.col);
     const dy = Math.sign(targetRow - unit.row);
-
-    // Try horizontal first, then vertical
     if (dx !== 0 && grid.isPassable(unit.col + dx, unit.row)) {
       unit.moveTo(unit.col + dx, unit.row);
     } else if (dy !== 0 && grid.isPassable(unit.col, unit.row + dy)) {
       unit.moveTo(unit.col, unit.row + dy);
-    } else if (dx !== 0 && dy !== 0) {
-      // Try the other axis
-      if (grid.isPassable(unit.col, unit.row + dy)) {
-        unit.moveTo(unit.col, unit.row + dy);
-      } else if (grid.isPassable(unit.col + dx, unit.row)) {
-        unit.moveTo(unit.col + dx, unit.row);
-      }
     }
   }
 
   private stepToward(unit: Unit, targetCol: number, targetRow: number, grid: TerrainGrid): void {
-    const dx = Math.sign(targetCol - unit.col);
-    const dy = Math.sign(targetRow - unit.row);
-    const preferHorizontal = Math.abs(targetCol - unit.col) >= Math.abs(targetRow - unit.row);
-
-    const tryMove = (dc: number, dr: number): boolean => {
-      if ((dc !== 0 || dr !== 0) && grid.isPassable(unit.col + dc, unit.row + dr)) {
-        unit.moveTo(unit.col + dc, unit.row + dr);
-        return true;
-      }
-      return false;
-    };
-
-    if (preferHorizontal) {
-      if (tryMove(dx, 0)) return;
-      if (tryMove(0, dy)) return;
-    } else {
-      if (tryMove(0, dy)) return;
-      if (tryMove(dx, 0)) return;
-    }
+    // Use BFS pathfinding (same as moveToward)
+    this.moveToward(unit, targetCol, targetRow, grid);
   }
 
   private wander(unit: Unit, grid: TerrainGrid): void {

--- a/src/terrain/TerrainGrid.ts
+++ b/src/terrain/TerrainGrid.ts
@@ -201,10 +201,61 @@ export class TerrainGrid {
     return TERRAIN_COLORS[terrain];
   }
 
+  /** BFS to find shortest path between two passable tiles. Returns the path (excluding start) or null. */
+  findPath(startCol: number, startRow: number, goalCol: number, goalRow: number): { col: number; row: number }[] | null {
+    if (!this.inBounds(startCol, startRow) || !this.inBounds(goalCol, goalRow)) return null;
+    if (startCol === goalCol && startRow === goalRow) return [];
+
+    const key = (c: number, r: number) => r * this.cols + c;
+    const visited = new Set<number>();
+    const prev = new Map<number, { col: number; row: number }>();
+    const queue: { col: number; row: number }[] = [{ col: startCol, row: startRow }];
+    visited.add(key(startCol, startRow));
+
+    const dirs = [{ dc: 1, dr: 0 }, { dc: -1, dr: 0 }, { dc: 0, dr: 1 }, { dc: 0, dr: -1 }];
+
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      for (const d of dirs) {
+        const nc = cur.col + d.dc;
+        const nr = cur.row + d.dr;
+        const nk = key(nc, nr);
+        if (!this.inBounds(nc, nr) || visited.has(nk) || !this.isPassable(nc, nr)) continue;
+        visited.add(nk);
+        prev.set(nk, { col: cur.col, row: cur.row });
+        if (nc === goalCol && nr === goalRow) {
+          // Reconstruct path
+          const path: { col: number; row: number }[] = [];
+          let c = nc, r = nr;
+          while (c !== startCol || r !== startRow) {
+            path.push({ col: c, row: r });
+            const p = prev.get(key(c, r))!;
+            c = p.col;
+            r = p.row;
+          }
+          path.reverse();
+          return path;
+        }
+        queue.push({ col: nc, row: nr });
+      }
+    }
+    return null; // unreachable
+  }
+
+  /** Check if a tile is reachable from another via passable tiles. */
+  isReachable(fromCol: number, fromRow: number, toCol: number, toRow: number): boolean {
+    return this.findPath(fromCol, fromRow, toCol, toRow) !== null;
+  }
+
   generateMap(): void {
     // River running roughly through the middle
     const midRow = Math.floor(this.rows / 2);
+    // Bridge positions at roughly 1/3 and 2/3 across the map
+    const bridge1 = Math.floor(this.cols / 3);
+    const bridge2 = Math.floor((this.cols * 2) / 3);
     for (let c = 0; c < this.cols; c++) {
+      // Skip river tiles at bridge positions to create passable gaps
+      if (c === bridge1 || c === bridge2) continue;
       const offset = Math.floor(Math.sin(c * 0.3) * 2);
       for (let dr = -1; dr <= 1; dr++) {
         const r = midRow + offset + dr;


### PR DESCRIPTION
## Summary
- 川に2箇所の橋を追加し、ユニットが南北を行き来可能にした
- AIの移動ロジックをBFSパスファインディングに置き換え、障害物を迂回できるようにした
- 敵スポーン位置を味方ユニットに到達可能なエリアに制限した

## Changes
- `src/terrain/TerrainGrid.ts`: `generateMap()` で川に橋を生成、`findPath()` / `isReachable()` BFSメソッド追加
- `src/systems/AISystem.ts`: `moveToward()` / `stepToward()` をBFSベースに改善
- `src/scenes/GameScene.ts`: `spawnEnemy()` に到達可能性チェック追加、初期スポーン位置修正

Ref #21

## Test plan
- [x] `npm run build` — ビルド成功
- [ ] 手動確認: アブラムシが橋を通って味方側に侵攻し戦闘が発生する

🤖 Generated with [Claude Code](https://claude.com/claude-code)