### PR TITLE
畑の設置場所をクリックで指定する機能が正しく動作しない

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -151,25 +151,35 @@ export class GameScene extends Phaser.Scene {
   }
 
   private handleClick(pointer: Phaser.Input.Pointer): void {
-    const worldX = pointer.worldX;
-    const worldY = pointer.worldY;
-    const { col, row } = this.hud.worldToTile(worldX, worldY);
+    const camera = this.cameras.main;
+    const worldPoint = camera.getWorldPoint(pointer.x, pointer.y);
+    const { col, row } = this.hud.worldToTile(worldPoint.x, worldPoint.y);
 
     if (!this.grid.inBounds(col, row)) return;
 
     if (this.hud.placementMode === "build") {
       if (this.grid.isBuildable(col, row)) {
         this.grid.startBuilding(col, row);
+      } else {
+        const reason = this.grid.getBuildBlockedReason(col, row);
+        this.hud.showFeedback(reason);
       }
     } else if (this.hud.placementMode === "seed") {
-      this.grid.seedFarm(col, row);
+      if (!this.grid.seedFarm(col, row)) {
+        const farm = this.grid.getCompletedFarm(col, row);
+        if (!farm) {
+          this.hud.showFeedback("ここには畑がないよ！");
+        } else if (farm.seeded) {
+          this.hud.showFeedback("もう種まき済みだよ！");
+        }
+      }
     }
   }
 
   private handleHover(pointer: Phaser.Input.Pointer): void {
-    const worldX = pointer.worldX;
-    const worldY = pointer.worldY;
-    const { col, row } = this.hud.worldToTile(worldX, worldY);
+    const camera = this.cameras.main;
+    const worldPoint = camera.getWorldPoint(pointer.x, pointer.y);
+    const { col, row } = this.hud.worldToTile(worldPoint.x, worldPoint.y);
 
     this.highlightGraphics.clear();
 

--- a/src/terrain/TerrainGrid.ts
+++ b/src/terrain/TerrainGrid.ts
@@ -73,6 +73,16 @@ export class TerrainGrid {
     return this.distanceToRiver(col, row) <= BUILDABLE_DISTANCE;
   }
 
+  getBuildBlockedReason(col: number, row: number): string {
+    if (!this.inBounds(col, row)) return "マップの外だよ！";
+    const terrain = this.grid[row][col];
+    if (terrain === TerrainType.River) return "川の上には建てられないよ！";
+    if (terrain === TerrainType.Limestone) return "石灰岩の上には建てられないよ！";
+    if (terrain === TerrainType.Farm) return "もう畑があるよ！";
+    if (this.distanceToRiver(col, row) > BUILDABLE_DISTANCE) return "川から遠すぎるよ！";
+    return "ここには建てられないよ！";
+  }
+
   private distanceToRiver(col: number, row: number): number {
     let minDist = Infinity;
     for (const rt of this.riverTiles) {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -7,8 +7,10 @@ export class HUD {
   private scene: Phaser.Scene;
   private modeText: Phaser.GameObjects.Text;
   private infoText: Phaser.GameObjects.Text;
+  private feedbackText: Phaser.GameObjects.Text;
   private buildBtn: Phaser.GameObjects.Text;
   private seedBtn: Phaser.GameObjects.Text;
+  private feedbackTimer?: Phaser.Time.TimerEvent;
   placementMode: PlacementMode = null;
 
   constructor(scene: Phaser.Scene) {
@@ -46,6 +48,14 @@ export class HUD {
     })
       .setScrollFactor(0)
       .setDepth(100);
+
+    this.feedbackText = scene.add.text(400, 14, "", {
+      fontSize: "14px",
+      color: "#ff6644",
+      fontStyle: "bold",
+    })
+      .setScrollFactor(0)
+      .setDepth(100);
   }
 
   toggleMode(mode: PlacementMode): void {
@@ -75,6 +85,16 @@ export class HUD {
 
   showTileInfo(col: number, row: number, terrain: string, extra: string): void {
     this.infoText.setText(`Tile (${col}, ${row}) — ${terrain}${extra ? "\n" + extra : ""}`);
+  }
+
+  showFeedback(message: string): void {
+    this.feedbackText.setText(message);
+    if (this.feedbackTimer) {
+      this.feedbackTimer.destroy();
+    }
+    this.feedbackTimer = this.scene.time.delayedCall(2000, () => {
+      this.feedbackText.setText("");
+    });
   }
 
   worldToTile(worldX: number, worldY: number): { col: number; row: number } {


### PR DESCRIPTION
## Summary
- クリック座標変換を `pointer.worldX/worldY` から `camera.getWorldPoint()` に変更し、カメラスクロール・ズーム時の位置ずれを修正
- 設置不可の場所（川、石灰岩、遠距離）クリック時にフィードバックメッセージを表示

## Changes
- `src/scenes/GameScene.ts`: `handleClick()` と `handleHover()` の座標変換を `camera.getWorldPoint()` に統一、設置不可フィードバック追加
- `src/terrain/TerrainGrid.ts`: `getBuildBlockedReason()` メソッド追加
- `src/ui/HUD.ts`: `showFeedback()` メソッドと feedbackText UI 追加

Ref #19

## Test plan
- [x] `tsc --noEmit` — 型チェック通過
- [x] `vite build` — ビルド通過
- [ ] カメラスクロール/ズーム後のクリック位置精度（手動テスト）
- [ ] 設置不可場所クリック時のフィードバック表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)